### PR TITLE
Adjust dependencies so install doesn't fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   "author": "Kevin M. Cunha",
   "license": "ISC",
   "dependencies": {
-    "lodash": "^4.16.2"
+    "babel-cli": "6.26.0",
+    "babel-preset-es2015": "6.24.1",
+    "babel-register": "6.26.0",
+    "lodash": "4.16.4"
   },
   "devDependencies": {
-    "babel-cli": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0",
-    "babel-register": "^6.14.0",
-    "eslint": "^3.6.0"
+    "eslint": "4.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/mitchellcunha/font-preloader",
   "scripts": {
     "lint": "eslint -c ./.eslintrc lib",
-    "install": "babel lib --presets babel-preset-es2015 --out-dir dist",
+    "install": "babel lib --presets babel-preset-env --out-dir dist",
     "release": "npm run lint && npm run install && npm version patch && npm publish"
   },
   "keywords": [
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "babel-cli": "6.26.0",
-    "babel-preset-es2015": "6.24.1",
+    "babel-preset-env": "1.6.0",
     "babel-register": "6.26.0",
     "lodash": "4.16.4"
   },


### PR DESCRIPTION
Hi Kevin!

We ran into a problem with this dependency when we replaced babel-preset-es2015 with the newer babel-preset-env.

The issue is that npm runs the install command defined in package.json, but when installed as a dependency, the devDependencies are missing. This was ok when our dependencies matched, but broke when we changed them.

The solution was to move some of the devDependencies to the dependencies section. I also upgraded a few things and switched to babel-preset-env here as well.

Thanks!